### PR TITLE
Improve speed of creating NanoDates from strings

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -225,13 +225,13 @@ function tooffset(str::AbstractString)
     sgn = 1
     if !isnothing(str) && !isempty(str) && length(str) > 3
         sgn = str[1] == '+' ? 1 : -1
-        hr = Meta.parse(str[2:3])
-        mn = Meta.parse(str[end-1:end])
+        hr = parse(Int, str[2:3])
+        mn = parse(Int, str[end-1:end])
     end
     copysign(hr, sgn), copysign(mn, sgn)
 end
 
-tosubsecs(ss::AbstractString) = tosubsecs(Meta.parse(rpad(ss, 9, '0')))
+tosubsecs(ss::AbstractString) = tosubsecs(parse(Int, rpad(ss, 9, '0')))
 
 function tosubsecs(ss::Integer)
     millis = micros = nanos = 0
@@ -284,7 +284,7 @@ function simpleparse(indices, str::AbstractString)
         subsec = filter(isdigit,subsec)[begin:min(end,begin+8)]    # ensure no more than 9 subsecond digits
         if !endswith(subsec, 'Z') && !occursin('+', subsec) && !occursin('-', subsec)
             subsec = rpad(subsec, 9, '0')
-            subsecs = tosubsecs(Meta.parse(subsec))
+            subsecs = tosubsecs(parse(Int, subsec))
             subseconds = Millisecond(subsecs[1]) + Microsecond(subsecs[2]) + Nanosecond(subsecs[3])
             return NanoDate(DateTime(supersec)) + subseconds
         else


### PR DESCRIPTION
The existing implementation uses `Meta.parse` to parse strings
as `Int`s, but this is type-unstable.

By replacing uses of `Meta.parse` with `Base.parse`, we can
improve the speed of constructing `NanoDate`s with `String`s 
several times over, reducing dynamic dispatch and allocations.

Before this commit:

```julia
julia> @benchmark NanoDate("2000-01-01T00:00:00.123456789")
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  41.872 μs …  4.764 ms  ┊ GC (min … max): 0.00% … 97.44%
 Time  (median):     43.145 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   44.887 μs ± 52.951 μs  ┊ GC (mean ± σ):  1.03% ±  0.97%

     ▃██▃
  ▂▃▆████▇▅▄▄▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  41.9 μs         Histogram: frequency by time        55.8 μs <

 Memory estimate: 5.69 KiB, allocs estimate: 81.
```

After this commit:
```julia
julia> @benchmark NanoDate("2000-01-01T00:00:00.123456789")
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   9.516 μs …  5.185 ms  ┊ GC (min … max): 0.00% … 98.95%
 Time  (median):     10.324 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.229 μs ± 51.838 μs  ┊ GC (mean ± σ):  4.57% ±  0.99%

     ▆█▆▃
  ▁▄██████▆▄▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  9.52 μs         Histogram: frequency by time        18.5 μs <

 Memory estimate: 5.42 KiB, allocs estimate: 71.
```

The current speed of parsing strings to `NanoDate`s is still vastly
slower than constructing `Dates.DateTime`s from strings (which takes
nanoseconds and does not allocate), but hopefully for now this small
change is welcome.  Longer-term, it would be great to get string
parsing as fast as `DateTime`s as this could be the bottleneck in
some applications.
