### PR TITLE
Remove unused code in parsing and speed parsing up

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -203,22 +203,6 @@ function nooffset(str::AbstractString)
 end
 
 
-separate_offset(df::DateFormat) = separate_offset(safestring(df))
-
-function separate_offset(str::AbstractString)
-    if isempty(str) || isdigit(str[end])
-        ("", "")
-    elseif endswith(str, 'Z')
-        ("", "Z")
-    elseif str[end-4:end] == "hh:mm"
-        (str[end-5], "hh:mm")
-    elseif str[end-3:end] == "hhmm"
-        (str[end-4], "hhmm")
-    else
-        throw(ArgumentError("offset in $(str) not recognized"))
-    end
-end
-
 function tooffset(str::AbstractString)
     hr = 0
     mn = 0
@@ -266,9 +250,6 @@ function NanoDate(str::AbstractString, df::DateFormat=ISONanoDateFormat; localti
         str = join(split(str, '_'))
     end
     indices = indexperiods(df)
-    somethings = map(!isnothing, Tuple(indices))
-    somekeys = keys(indices)[[somethings...]]
-    someindices = NamedTuple{somekeys}(indices)
     parts = getparts(indices, str)
     subsecs = isnothing(parts.ss) ? (0,0,0) : tosubsecs(parts.ss)
     offsets = isnothing(parts.offset) ? (0,0) : tooffset(parts.offset)


### PR DESCRIPTION
The `NanoDate(::AbstractString, ::DateFormat)` constructor previously
created a few variables which are never used, so remove these lines.
These lines are actually responsible for about half the running time of
calls to the constructor, so this change doubles the speed of parsing.

Also remove the unused `separate_offset` methods.
