### PR TITLE
Fix inference problem in unix conversion methods

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -48,7 +48,11 @@ end
 function unixnanos2nanodate(nanosecs)
     millis, micronanos = fldmod(nanosecs, 1_000_000)
     ndays, millis = fldmod(millis, 86400_000)
-    dtm = DateTime(1970) + Day(ndays) + Millisecond(millis)
+    # Parenthesize so each `+` dispatches to the binary `+(::DateTime, ::Period)`
+    # method (which returns `DateTime`). Writing `a + b + c` would otherwise be
+    # parsed as a 3-arg `+`, hitting `Dates`'s varargs `+(::TimeType, ::Period...)`
+    # method whose return type does not infer, making this function return `Any`.
+    dtm = (DateTime(1970) + Day(ndays)) + Millisecond(millis)
     NanoDate(dtm, Nanosecond(micronanos))
 end
 

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -35,3 +35,10 @@ end
     @test nd - NanoDate(nd, Ns-Nanosecond(999)) == Nanosecond(999)
 end
 
+@testset "unix" begin
+    @test unixnanos2nanodate(0) == NanoDate(DateTime(1970))
+    @test nanodate2unixnanos(unixnanos2nanodate(123_456_789)) == 123_456_789
+    # `unixnanos2nanodate` must be type-stable (returns `NanoDate`, not `Any`).
+    @test Base.return_types(unixnanos2nanodate, Tuple{Int64}) == [NanoDate]
+end
+


### PR DESCRIPTION
The 3-arg `+` calls a `varargs` method in `Dates`, which does not infer. Use two 2-arg `+` calls by using parentheses instead.

main:
```julia
julia> @b unixnanos2nanodate($123456789)
170.276 ns (8 allocs: 192 bytes)
```

This PR:
```julia
julia> @b unixnanos2nanodate($123456789)
5.637 ns
```

I'll try to fix this in `Dates`. However, even if possible and accepted into Julia 1.14, it will take a long time until every Julia version with this problem is out of support, so the fix should be in `NanoDates` for some years.